### PR TITLE
Add support for zero-amount Lightning invoice payments

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -3629,7 +3629,6 @@ pub(crate) async fn send_payment(
             ) {
                 Ok(_) => {
                     let payee_pubkey = invoice.recover_payee_pub_key();
-                    let amt_msat = invoice.amount_milli_satoshis().unwrap();
                     tracing::info!(
                         "EVENT: initiated sending {} msats to {}",
                         amt_msat,


### PR DESCRIPTION
- Add test case for zero-amount invoice payment in payment module
- Fix panic in send_payment function when handling zero-amount invoices
- Remove redundant unwrap() that was shadowing properly-calculated amt_msat
- Zero-amount invoices now properly accept explicit payment amounts
- Format code with cargo fmt